### PR TITLE
Add temporal information

### DIFF
--- a/src/middleware/Map.js
+++ b/src/middleware/Map.js
@@ -41,8 +41,9 @@ export default {
     else return ApiVGI().get('/api/user_layer/')
   },
 
-  getTemporalData() {
-    return ApiVGI().get('/api/temporal_columns/')
+  getTemporalData(query) {
+    if(query != null) return ApiVGI().get(`/api/temporal_columns/?${query}`);
+    else return ApiVGI().get("/api/temporal_columns/");
   },
 
   getPlacesList() {

--- a/src/middleware/Map.js
+++ b/src/middleware/Map.js
@@ -41,6 +41,10 @@ export default {
     else return ApiVGI().get('/api/user_layer/')
   },
 
+  getTemporalData() {
+    return ApiVGI().get('/api/temporal_columns/')
+  },
+
   getPlacesList() {
     return ApiGeocoding().get('/placeslist')
   }

--- a/src/tests/features/bdd/search_temporal_data_add_layer.feature
+++ b/src/tests/features/bdd/search_temporal_data_add_layer.feature
@@ -1,0 +1,8 @@
+# language: pt
+
+Funcionalidade: Pesquisar informações temporais de camadas no menu de adicionar e remover camadas
+
+Cenário: Pesquisar informações temporais de camadas no menu de adicionar e remover camadas
+Dado que eu esteja na tela de adicionar e remover camadas
+E eu pesquiso por "31/12/1975"
+Então todos os resultados visiveis devem conter "31/12/1975"

--- a/src/tests/features/bdd/temporal_data_add_layer.feature
+++ b/src/tests/features/bdd/temporal_data_add_layer.feature
@@ -1,0 +1,7 @@
+# language: pt
+
+Funcionalidade: Ver informações temporais da camada no menu de adicionar e remover camadas
+
+Cenário: Ver informações temporais da camada no menu de adicionar e remover camadas
+Dado que eu esteja na tela de adicionar e remover camadas
+Então eu devo ver a informação temporal "DADOS TEMPORAIS: 01/01/1869 até 31/12/1975" na camada "Addresses in 1869"

--- a/src/tests/features/bdd/temporal_data_layer_information.feature
+++ b/src/tests/features/bdd/temporal_data_layer_information.feature
@@ -1,0 +1,11 @@
+# language: pt
+
+Funcionalidade: Ver informações temporais da camada no modal de ver informações da camada
+
+Cenário: Ver informações temporais da camada no modal de ver informações da camada
+Dado que eu esteja na tela de adicionar e remover camadas
+E adicione a camada "Addresses in 1869" a visualização
+E fecho a tela de adicionar e remover camadas
+E eu clico no botão de configurações da camada "Addresses in 1869"
+E eu clico no botão de ver informações da camada "Addresses in 1869"
+Então eu devo ver a informação temporal "DADOS TEMPORAIS: 01/01/1869 até 31/12/1975" no menu de informações da camada "Addresses in 1869"

--- a/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
@@ -1,0 +1,9 @@
+Dado('eu pesquiso por {string}') do |termo_pesquisa|
+  find('input[placeholder="Pesquise por tema, camada, autor ou dados temporais:"]').set(termo_pesquisa)
+end
+
+Então('todos os resultados visiveis devem conter {string}') do |termo_pesquisa|
+  elements = all('.box-layer-info')
+  all_elements_contain_search = elements.all? { |element| element.text.include?(termo_pesquisa) }
+  expect(all_elements_contain_search).to be true
+end

--- a/src/tests/features/step_definitions/temporal_data_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/temporal_data_add_layer_steps.rb
@@ -1,0 +1,8 @@
+Dado('que eu esteja na tela de adicionar e remover camadas') do
+  visit('http://localhost:8080/portal/explore')
+  find('p.btn_sidebar').click
+  find('div.md-button-content img[src="/portal/static/img/add-layer.5bcee7e.png"]').find(:xpath, '..').click
+end
+Então('eu devo ver a informação temporal {string} na camada {string}') do |informacao_temporal, camada|
+    expect(page).to have_content(informacao_temporal)
+end

--- a/src/tests/features/step_definitions/temporal_data_layer_information_steps.rb
+++ b/src/tests/features/step_definitions/temporal_data_layer_information_steps.rb
@@ -1,0 +1,22 @@
+Dado('adicione a camada {string} a visualização') do |camada|
+  element = find('div.box-layer-info p', text: "TÍTULO: #{camada}").ancestor('.box-layer-info')
+  element.find('button', text: "Ativar").click
+end
+
+Quando('eu clico no botão de ver informações da camada {string}') do |camada|
+  find('i.md-icon', text: 'assignment').click
+end
+
+E('fecho a tela de adicionar e remover camadas') do
+  find('button[data-dismiss="modal"][aria-label="Close"]').click
+end
+
+Então('eu devo ver a informação temporal {string} no menu de informações da camada {string}') do |informacao_temporal, camada|
+  expect(page).to have_content(informacao_temporal)
+end
+
+Quando('eu clico no botão de configurações da camada {string}') do |camada|
+  layer = find('span', text: "#{camada}")
+  settings = layer.find('button.btn-view i.md-icon', text: 'settings')
+  settings.click
+end

--- a/src/views/components/map/BoxInfoLayer.vue
+++ b/src/views/components/map/BoxInfoLayer.vue
@@ -31,6 +31,7 @@
                     </el-tag>
                 </li>
                 <li><b>{{ $t('map.viewInfo.lbDescription') }}:</b> {{ infos.description }} </li>
+                <li><b>{{ $t('map.viewInfo.lbTemporalData') }}:</b> {{ infos.startDate }} {{ $t('map.viewInfo.lbUntil') }} {{ infos.endDate }} </li>
                 <li><b>{{ $t('map.viewInfo.lbDate') }}:</b> {{ infos.date }}</li>
                 <li><b>{{ $t('map.viewInfo.lbAuthors') }}:</b>
                     <span v-show="layer != null" v-for="author in infos.authors" :key="author.properties.user_id">
@@ -394,11 +395,17 @@ export default {
             let layers = await Map.getLayers('layer_id='+this.id)
             this.layer = layers.data.features[0].properties
 
+            let temporalData = await Map.getTemporalData("f_table_name=" + this.layer.f_table_name)
+            let startDate = temporalData.data.features[0].properties.start_date;
+            let endDate = temporalData.data.features[0].properties.end_date;
+
             this.infos.name = this.layer.name
             this.infos.description = this.layer.description
             this.infos.keywords = this.layer.keyword
             this.infos.references = this.layer.reference
             this.infos.authors = this.allAuthorsLayers.filter( item => item.properties.layer_id == this.layer.layer_id )
+            this.infos.startDate = this._getDate(startDate);
+            this.infos.endDate = this._getDate(endDate);
 
             this.infos.date = this._getDate(this.layer.created_at)
         },

--- a/src/views/components/map/sidebar-layer/AddLayers.vue
+++ b/src/views/components/map/sidebar-layer/AddLayers.vue
@@ -72,7 +72,10 @@ export default {
           this.listLayers = this.allLayers.filter(layer => {
             if (layer.properties.name.toLowerCase().indexOf(val.toLowerCase()) >= 0 ||
                 layer.properties.authors.toString().toLowerCase().indexOf(val.toLowerCase()) >= 0 ||
-                layer.properties.keyword.toString().toLowerCase().indexOf(val.toLowerCase()) >= 0 )
+                layer.properties.keyword.toString().toLowerCase().indexOf(val.toLowerCase()) >= 0 ||
+                layer.properties.start_date.toLowerCase().indexOf(val.toLowerCase()) >= 0 ||
+                layer.properties.end_date.toLowerCase().indexOf(val.toLowerCase()) >= 0
+                )
                   return layer
           })
         }

--- a/src/views/components/map/sidebar-layer/AddLayers.vue
+++ b/src/views/components/map/sidebar-layer/AddLayers.vue
@@ -20,6 +20,7 @@
             <div :class="layers.some(id => id == layer.properties.layer_id) ? 'box-layer-info activated' : 'box-layer-info disabled'">
               <div class="infos">
                 <p><strong>{{ $t('map.addLayer.box.lbTitle') }}:</strong> {{ layer.properties.name }}</p>
+                <p><strong>{{ $t('map.addLayer.box.lbTemporalData') }}:</strong> {{ layer.properties.start_date }} {{ $t('map.addLayer.box.lbUntil') }} {{ layer.properties.end_date }}</p>
                 <p><strong>{{ $t('map.addLayer.box.lbAuthors') }}:</strong>
                   <span v-for="name in layer.properties.authors" :key="name">
                     {{ name }};
@@ -88,7 +89,8 @@ export default {
         listLayers: [],
         allLayers: [],
         allKeywords: [],
-        allAuthorsLayers: []
+        allAuthorsLayers: [],
+        allTemporalData: [],
       }
     },
     async mounted() {
@@ -105,6 +107,9 @@ export default {
         result = await Map.getAuthorsLayers(null)
         this.allAuthorsLayers = result.data.features
 
+        result = await Map.getTemporalData();
+        this.allTemporalData = result.data.features;
+
         // add a list of authors and keywords names inside each layer
         this.allLayers.forEach(layer => {
           layer.properties.authors = this.allAuthorsLayers.filter(
@@ -119,6 +124,10 @@ export default {
           layer.properties.keyword = layer.properties.keyword.map(
             id => this.getKeywordById(id)[0].properties.name
           )
+
+          const temporalData = this.getTemporalDataByFTableName(layer.properties.f_table_name)[0].properties;
+          layer.properties.start_date = this._getDate(temporalData.start_date);
+          layer.properties.end_date = this._getDate(temporalData.end_date);
         })
 
         // sort the layers by name
@@ -143,6 +152,9 @@ export default {
       },
       getAuthorById(id){
         return this.allAuthors.filter(author => author.properties.user_id === id)
+      },
+      getTemporalDataByFTableName(f_table_name) {
+        return this.allTemporalData.filter(temporalData => temporalData.properties.f_table_name === f_table_name);
       },
       disabled(layer) {
         if(this.btnDisabled == false)
@@ -207,6 +219,26 @@ export default {
           spinner: 'el-icon-loading',
           background: 'rgba(0, 0, 0, 0.7)'
         })
+      },
+      _getDate(date) {
+        let dateParsed = date.split("-");
+        if (this.$i18n.locale() == "pt") {
+          return (
+            dateParsed[2].split(" ")[0] +
+            "/" +
+            dateParsed[1] +
+            "/" +
+            dateParsed[0]
+          );
+        } else {
+          return (
+            dateParsed[1] +
+            "/" +
+            dateParsed[2].split(" ")[0] +
+            "/" +
+            dateParsed[0]
+          );
+        }
       }
     }
 }

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -277,7 +277,7 @@ export default {
         },
         "addLayer": {
             "title": "Add or remove layers",
-            "input": "Search by theme, layer or author:",
+            "input": "Search by theme, layer, author or temporal data:",
             "close": "Close",
             "box": {
                 "lbTitle": "TITLE",

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -304,6 +304,8 @@ export default {
             "lbAuthors": "AUTHORS",
             "lbDate": "CREATION DATE",
             "lbReferences": "REFERENCES",
+            "lbTemporalData": "TEMPORAL DATA",
+            "lbUntil": "to",
             "lbNotifications": "Notifications"
         },
         "viewInfoVector": {

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -282,7 +282,9 @@ export default {
             "box": {
                 "lbTitle": "TITLE",
                 "lbAuthors": "AUTHORS",
-                "lbKeywods": "KEYWORDS"
+                "lbKeywods": "KEYWORDS",
+                "lbTemporalData": "TEMPORAL DATA",
+                "lbUntil": "to",
             },
             "btns": {
                 "active": "Active",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -283,7 +283,9 @@ export default {
             "box": {
                 "lbTitle": "TÍTULO",
                 "lbAuthors": "AUTORES",
-                "lbKeywods": "PALAVRAS-CHAVE"
+                "lbKeywods": "PALAVRAS-CHAVE",
+                "lbTemporalData": "DADOS TEMPORAIS",
+                "lbUntil": "até",
             },
             "btns": {
                 "active": "Ativar",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -278,7 +278,7 @@ export default {
         },
         "addLayer": {
             "title": "Adicionar e remover camadas",
-            "input": "Pesquise por tema, camada ou autor:",
+            "input": "Pesquise por tema, camada, autor ou dados temporais:",
             "close": "Fechar",
             "box": {
                 "lbTitle": "TÍTULO",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -305,6 +305,8 @@ export default {
             "lbAuthors": "AUTORES",
             "lbDate": "DATA DE CRIAÇÃO",
             "lbReferences": "REFERÊNCIAS",
+            "lbTemporalData": "DADOS TEMPORAIS",
+            "lbUntil": "até",
             "lbNotifications": "Notificações"
         },
         "viewInfoVector": {


### PR DESCRIPTION
Added temporal information to add layers cards, layer information modal and to add layer search. All changes were made with TDD. The tests for this PR are inside feature and steps folders with names: temporal_data_add_layer and temporal_data_layer_information. To ensure code quality, the code was passed through codalyzer and code climate. No code smells were detected on the added code. Earlier made acceptance tests were executed to make sure that no other part of the application was damaged by the additions of this PR.

No big structural changes were made. When adding this contribution to the code, only some translations and the vue component files will be changed with the inclusion of data getting and showing in the template, as well as the data variables relating to the new data.