### PR TITLE
Download maps feature

### DIFF
--- a/src/store/modules/map.js
+++ b/src/store/modules/map.js
@@ -4,10 +4,12 @@ const state = {
     last: 1940
   },
   layers: [],
+  mapLayers: [],
   boxGeocoding: true,
   boxInfoLayer: false,
   boxNotifications: false,
   boxInfoVector: false,
+  boxDownloadMap: false,
   boxSubtitle: false,
   boxAlert: true,
   //informação do layer
@@ -40,6 +42,9 @@ const mutations = {
   setBoxInfoVector (state, value) {
     state.boxInfoVector = value
   },
+  setBoxDownloadMap (state, value) {
+    state.boxDownloadMap = value
+  },
   setNewLayers (state, value) {
     state.layers.push(value)
   },
@@ -54,6 +59,9 @@ const mutations = {
   },
   setSidebar (state, value) {
     state.sidebar = value
+  },
+  setMapLayers(state, value) {
+    state.mapLayers = value
   }
 }
 
@@ -63,6 +71,9 @@ const actions = {
   },
   setBoxGeocoding({commit}, value) {
     commit('setBoxGeocoding', value)
+  },
+  setBoxDownloadMap({commit}, value) {
+    commit('setBoxDownloadMap', value)
   },
   setBoxSubtitle({commit}, value) {
     commit('setBoxSubtitle', value)
@@ -93,6 +104,9 @@ const actions = {
   },
   setSidebar ({commit}, value) {
     commit('setSidebar', value)
+  },
+  setMapLayers({commit}, value) {
+    commit('setMapLayers', value)
   }
 }
 

--- a/src/tests/features/bdd/open_background_map_openlayers.feature
+++ b/src/tests/features/bdd/open_background_map_openlayers.feature
@@ -1,0 +1,23 @@
+# language: pt
+
+Funcionalidade: Abrir mapa de fundo no OpenLayers
+
+Cenário: Mapa de fundo selecionado e redirecionamento confirmado
+Dado que eu esteja na tela de opções de download
+Quando há um mapa de fundo selecionado
+E eu clico no botão "Mapa de fundo"
+E clico em "Sim"
+Então deve abrir uma nova aba do OpenLayers
+
+Cenário: Mapa de fundo selecionado e redirecionamento cancelado
+Dado que eu esteja na tela de opções de download
+Quando há um mapa de fundo selecionado
+E eu clico no botão "Mapa de fundo"
+E clico em "Voltar"
+Então o popup de confirmação deve sumir
+
+Cenário: Nenhum mapa de fundo selecionado
+Dado que eu esteja na tela de opções de download
+Quando não há um mapa de fundo selecionado
+E eu clico no botão "Mapa de fundo"
+Então deve aparecer uma mensagem de erro

--- a/src/tests/features/bdd/open_download_options.feature
+++ b/src/tests/features/bdd/open_download_options.feature
@@ -1,0 +1,18 @@
+# language: pt
+
+Funcionalidade: Abrir opções de download
+
+Cenário: Abrir tela com as opções de download
+Dado que eu esteja na tela de explorar o mapa
+Quando eu clico no ícone de download
+Então deve aparecer uma tela com os botões "Visualização atual" e "Mapa de fundo"
+# E clico em "Mapa de fundo"
+# E clico em "Sim"
+# Então deve abrir uma nova aba com o mapa selecionado
+
+# Cenário: Baixar mapa de fundo quando não há um mapa ativo
+# Dado que eu esteja na tela de explorar o mapa
+# Quando eu clico no ícone de download
+# E clico em "Mapa de fundo"
+# Se nenhum mapa estiver selecionado
+# Então deve aparecer um erro

--- a/src/tests/features/step_definitions/open_background_map_openlayers_steps.rb
+++ b/src/tests/features/step_definitions/open_background_map_openlayers_steps.rb
@@ -1,0 +1,36 @@
+Dado('que eu esteja na tela de opções de download') do
+    visit('http://localhost:8080/portal/explore')
+    find("#close-alert").click
+    find('#download-map').click
+end
+
+Quando('há um mapa de fundo selecionado') do
+    find('p.btn_sidebar').click
+    find(:xpath, '(//div[@class="el-switch is-checked"])[2]')
+end
+
+Quando('não há um mapa de fundo selecionado') do
+    find('p.btn_sidebar').click
+    find(:xpath, '(//div[@class="el-switch is-checked"])[2]').click
+end
+
+E('eu clico no botão {string}') do | buttonText |
+    find("button", :text => buttonText).click
+end
+
+E("clico em {string}") do | buttonText |
+    find(".popup-modal")
+    find("button", :text => buttonText).click
+end
+
+Então("o popup de confirmação deve sumir") do
+    find(".fade-leave-to")
+end
+
+Então("deve abrir uma nova aba do OpenLayers") do
+    page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
+end
+
+Então("deve aparecer uma mensagem de erro") do 
+    find(".el-message-box")
+end

--- a/src/tests/features/step_definitions/open_download_options_steps.rb
+++ b/src/tests/features/step_definitions/open_download_options_steps.rb
@@ -1,0 +1,25 @@
+Dado('que eu esteja na tela de explorar o mapa') do
+    visit('http://localhost:8080/portal/explore')
+    find("#close-alert").click
+end
+
+Quando('eu clico no ícone de download') do
+    find('#download-map').click
+end
+
+Então('deve aparecer uma tela com os botões {string} e {string}') do |button1, button2|
+    find("button", :text => button1)
+    find("button", :text => button2)
+end
+# E('clico em "Mapa de fundo"') do
+#     find('#download-background-map').click
+# end
+
+# E('clico em "Sim"') do
+#     find("#ok-button").click
+# end
+
+# Então("deve abrir uma nova aba com o mapa selecionado") do
+#     page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
+# end
+  

--- a/src/views/components/PopupModal.vue
+++ b/src/views/components/PopupModal.vue
@@ -1,0 +1,63 @@
+<template>
+    <transition name="fade">
+        <div class="popup-modal" v-if="isVisible">
+            <div class="window">
+                <slot></slot>
+            </div>
+        </div>
+    </transition>
+</template>
+
+<script>
+export default {
+    name: 'PopupModal',
+
+    data: () => ({
+        isVisible: false,
+    }),
+
+    methods: {
+        open() {
+            this.isVisible = true
+        },
+
+        close() {
+            this.isVisible = false
+        },
+    },
+}
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.3s;
+}
+.fade-enter,
+.fade-leave-to {
+    opacity: 0;
+}
+
+.popup-modal {
+    background-color: rgba(0, 0, 0, 0.5);
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    z-index: 1;
+}
+
+.window {
+    background: #fff;
+    border-radius: 5px;
+    box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.2);
+    max-width: 480px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1rem;
+}
+</style>

--- a/src/views/components/aside-right/Main.vue
+++ b/src/views/components/aside-right/Main.vue
@@ -18,6 +18,13 @@
                 :class="this.boxNotifications ? 'btn active' : 'btn'">
                 <md-icon>message</md-icon>
             </button>
+
+            <button type="button"
+                id="download-map"
+                @click="actDownloadMap()"  
+                :class="this.boxDownloadMap ? 'btn active' : 'btn'">
+                <md-icon>arrow_circle_down</md-icon>
+            </button>
         </section>
 
         <div class="box-bottom">
@@ -35,7 +42,7 @@ import { mapState } from 'vuex'
 
 export default {
     computed: {
-        ...mapState('map', ['boxGeocoding', 'boxInfoLayer', 'boxInfoVector', 'boxNotifications'])
+        ...mapState('map', ['boxGeocoding', 'boxInfoLayer', 'boxInfoVector', 'boxNotifications', 'boxDownloadMap'])
     },
 
     methods: {
@@ -43,19 +50,29 @@ export default {
             this.$store.dispatch('map/setBoxInfoLayer', false)
             this.$store.dispatch('map/setBoxGeocoding', false)
             this.$store.dispatch('map/setBoxNotifications', false)
+            this.$store.dispatch('map/setBoxDownloadMap', false)
             this.$store.dispatch('map/setBoxInfoVector', !this.boxInfoVector)
         },
         actNotifications() {
             this.$store.dispatch('map/setBoxInfoLayer', false)
             this.$store.dispatch('map/setBoxInfoVector', false)
             this.$store.dispatch('map/setBoxGeocoding', false)
+            this.$store.dispatch('map/setBoxDownloadMap', false)
             this.$store.dispatch('map/setBoxNotifications', !this.boxNotifications)
         },
         actGeocoding() {
             this.$store.dispatch('map/setBoxInfoLayer', false)
             this.$store.dispatch('map/setBoxInfoVector', false)
             this.$store.dispatch('map/setBoxNotifications', false)
+            this.$store.dispatch('map/setBoxDownloadMap', false)
             this.$store.dispatch('map/setBoxGeocoding', !this.boxGeocoding)
+        },
+        actDownloadMap() {
+            this.$store.dispatch('map/setBoxInfoLayer', false)
+            this.$store.dispatch('map/setBoxInfoVector', false)
+            this.$store.dispatch('map/setBoxNotifications', false)
+            this.$store.dispatch('map/setBoxGeocoding', false)
+            this.$store.dispatch('map/setBoxDownloadMap', !this.boxDownloadMap)
         }
     }
 }

--- a/src/views/components/dashboard/ConfirmationModal.vue
+++ b/src/views/components/dashboard/ConfirmationModal.vue
@@ -1,0 +1,67 @@
+<template>
+    <popup-modal ref="popup" name="confirmation-popup">
+        <h2 style="margin-top: 0">{{ title }}</h2>
+        <p>{{ message }}</p>
+        <div class="btns">
+            <button class="btn btn-secondary" @click="_cancel">{{ cancelButton }}</button>
+            <button class="btn btn-success" name="ok-button" @click="_confirm">{{ okButton }}</button>
+        </div>
+    </popup-modal>
+</template>
+
+<script>
+    import PopupModal from '../PopupModal.vue'
+
+  export default {
+    name: "ConfirmationModal",
+    components: {
+      PopupModal
+    },
+    data: () => ({
+        title: undefined,
+        message: undefined, 
+        okButton: undefined, 
+        cancelButton: 'Voltar',
+    
+        resolvePromise: undefined,
+        rejectPromise: undefined,
+    }),
+
+    methods: {
+        show(opts = {}) {
+            this.title = opts.title
+            this.message = opts.message
+            this.okButton = opts.okButton
+            if (opts.cancelButton) {
+                this.cancelButton = opts.cancelButton
+            }
+            
+            this.$refs.popup.open()
+            
+            return new Promise((resolve, reject) => {
+                this.resolvePromise = resolve
+                this.rejectPromise = reject
+            })
+        },
+
+        _confirm() {
+            this.$refs.popup.close()
+            this.resolvePromise(true)
+        },
+
+        _cancel() {
+            this.$refs.popup.close()
+            this.resolvePromise(false)
+        },
+    },
+  }
+
+</script>
+
+<style scoped>
+.btns {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+</style>

--- a/src/views/components/map/BoxDownloadMap.vue
+++ b/src/views/components/map/BoxDownloadMap.vue
@@ -1,0 +1,130 @@
+<template>
+    <div class="box-info" v-show="boxDownloadMap">
+        <header class="header">
+            <h1>{{ $t('map.viewDownloadMap.title') }}</h1>
+            <button class="btn" @click="closeBox()">
+                <md-icon>close</md-icon>
+            </button>
+        </header>
+        <div class="body">
+            <div class="row justify-content-md-center">
+                <button class="btn btn-success" @click="downloadView()">{{ $t('map.viewDownloadMap.btnFeature') }}</button>
+                <button class="btn btn-secondary" id="download-background-map" @click="downloadBackgroundMap()">{{ $t('map.viewDownloadMap.btnBox') }}</button>
+                <confirmation-modal ref="confirmationModal"></confirmation-modal>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import ConfirmationModal from '../dashboard/ConfirmationModal.vue'
+
+export default {
+    components:{ ConfirmationModal },
+    computed: {
+      ...mapState('map', ['boxDownloadMap', 'layers']),
+    },
+    methods: {
+        closeBox() {
+            this.$store.dispatch('map/setBoxDownloadMap', false)
+        },
+        async downloadView() {
+            const canvas = document.getElementsByTagName('canvas')[0];
+            const imagemURL = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+            
+            const element = document.createElement('a');
+            const filename = 'visualizacao_atual.png';
+            element.setAttribute('href', imagemURL);
+            element.setAttribute('download', filename);
+
+            element.click();    
+        },
+        async downloadBackgroundMap() {
+            const mapLayers = this.$store.state.map.mapLayers
+            const selectedMapLayer = mapLayers.filter(el => el.status)
+            
+            if (selectedMapLayer.length == 0) {
+                this.$alert(this.$t('map.viewDownloadMap.msg.errMsg'), this.$t('map.viewDownloadMap.msg.errTitle'), {
+                    confirmButtonText: 'OK',
+                    type: 'error'
+                })
+                return;
+            }
+            const layerName = selectedMapLayer[0].title;
+
+            const ok = await this.$refs.confirmationModal.show({
+                title: this.$t('map.viewDownloadMap.modalTitle'),
+                message: this.$t('map.viewDownloadMap.modalText'),
+                okButton: this.$t('map.viewDownloadMap.modalBtnConfirm'),
+                cancelButton: this.$t('map.viewDownloadMap.modalBtnCancel'),
+            })
+
+            if (ok) {
+                const width = window.innerWidth
+                const height = window.innerHeight
+                let url = process.env.urlGeoserverPauliceia+'/wms/reflect?format=application/openlayers&layers=pauliceia%3A'+layerName+'&height='+height+'&width='+width+'#toggle';
+                
+                window.open(url, '_blank', 'noreferrer');
+            } 
+        },
+    }
+}
+</script>
+
+<style lang="sass" scoped>
+.box-info
+    position: absolute
+    top: 20px
+    right: 60px
+    border-radius: 10px
+    overflow: auto
+    padding: 10px
+    background: rgba(#FFF, 0.7)
+    z-index: 1
+    max-width: 50%
+    min-width: 40%
+    max-height: 75%
+
+    .header
+        width: 100%
+        border-bottom: 1px solid #f15a29
+        h1
+            padding: 5px 5px 10px 5px
+            font-size: 1.3em
+            font-weight: 400
+            font-family: 'Roboto' !important
+            display: inline-block
+            margin: 0 !important
+
+        .btn
+            margin: 3px !important
+            padding: 2px !important
+            background: none
+            font-size: 1em
+            border: none
+            float: right
+            display: inline-block
+        .btn:hover
+            background: rgba(#000, 0.1)
+
+    .body
+        padding: 15px 10px
+        background: #FFF
+        button
+            margin: 0 10px 0 0
+
+        .result
+            p
+                font-size: 1.3em
+                font-weight: 700
+                padding: 0px 10px
+                margin: 25px 2px 10px 2px
+                border-left: 2px solid #000
+
+            .table td
+                border: 1px solid #CCC
+            .table
+                background: rgba(#000, 0.03)
+
+</style>

--- a/src/views/components/map/sidebar-layer/LayersItem.vue
+++ b/src/views/components/map/sidebar-layer/LayersItem.vue
@@ -216,6 +216,7 @@ export default {
                 this.$store.dispatch('map/setBoxInfoVector', false)
                 this.$store.dispatch('map/setBoxGeocoding', false)
                 this.$store.dispatch('map/setBoxNotifications', false)
+                this.$store.dispatch('map/setBoxDownloadMap', false)
 
                 this.$store.dispatch('map/setBoxInfoLayer', true)
                 this.$store.dispatch('map/setIdInfoLayer', this.id)

--- a/src/views/components/map/sidebar-layer/LayersItemRasters.vue
+++ b/src/views/components/map/sidebar-layer/LayersItemRasters.vue
@@ -11,10 +11,14 @@
 import {
     overlayGroupRasters
 } from '@/views/assets/js/map/overlayGroup'
+import { mapState } from 'vuex'
 
 export default {
     props: {
         color: String
+    },
+    computed: {
+        ...mapState('map', ['mapLayers'])
     },
     data() {
         return {
@@ -73,6 +77,7 @@ export default {
     },
     created() {
         overlayGroupRasters.getLayers().clear()
+        this.$store.dispatch('map/setMapLayers', this.layers);
 
         overlayGroupRasters.getLayers().push(
             new ol.layer.Tile({
@@ -87,7 +92,8 @@ export default {
                         STYLES: '',
                         LAYERS: 'pauliceia:1930_1_1000',
                         tilesOrigin: 330937.3300521516 + ',' + 7393691.47872888
-                    }
+                    },
+                    crossOrigin: "Anonymous"
                 })
             })
         )
@@ -96,7 +102,7 @@ export default {
         modifyLayer(layerSelected) {
             if(overlayGroupRasters.getLayers().getLength() > 0)
                 overlayGroupRasters.getLayers().pop()
-
+            
             if(layerSelected.status == true) {
                 for(var i in this.layers){
                     if(this.layers[i].title != layerSelected.title)
@@ -122,10 +128,12 @@ export default {
                                 STYLES: '',
                                 LAYERS: 'pauliceia:' + layerSelected.title,
                                 tilesOrigin: 330937.3300521516 + ',' + 7393691.47872888
-                            }
+                            },
+                            crossOrigin: "Anonymous"
                         })
                     })
                 )
+                this.$store.dispatch('map/setMapLayers', this.layers);
                 this.loading.close()
             }
         },

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -307,7 +307,7 @@ export default {
             "lbAuthors": "AUTHORS",
             "lbDate": "CREATION DATE",
             "lbReferences": "REFERENCES",
-            "lbTemporalData": "TEMPORAL DATA",
+"lbTemporalData": "TEMPORAL DATA",
             "lbUntil": "to",
             "lbNotifications": "Notifications"
         },
@@ -316,6 +316,20 @@ export default {
             "btnFeature": "By location",
             "btnBox": "By region",
             "btnClean": "Clean"
+        },
+        "viewDownloadMap": {
+            "title": "Download map",
+            "btnFeature": "Actual view",
+            "btnBox": "Background map",
+            "modalText": `Due the map high resolution, it is not possible to download it, but you can view it using OpenLayers. 
+                            It will open a new tab, do you want to continue?`,
+            "modalTitle": "Download map",
+            "modalBtnConfirm": "Yes",
+            "modalBtnCancel": "Go back",
+            "msg": {
+                "errTitle": "None map layer selected",
+                "errMsg": "Select a map layer before trying to download it"
+            }
         },
         "betaVersionModal": {
             "welcome": "Welcome to the `Pauliceia 2.0` platform",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -279,7 +279,7 @@ export default {
         "addLayer": {
             "title": "Adicionar e remover camadas",
             "input": "Pesquise por tema, camada, autor ou dados temporais:",
-            "initialDate": "Data inicial",
+"initialDate": "Data inicial",
             "finalDate": "Data final",
             "author": "Autor",
             "close": "Fechar",
@@ -308,7 +308,7 @@ export default {
             "lbAuthors": "AUTORES",
             "lbDate": "DATA DE CRIAÇÃO",
             "lbReferences": "REFERÊNCIAS",
-            "lbTemporalData": "DADOS TEMPORAIS",
+"lbTemporalData": "DADOS TEMPORAIS",
             "lbUntil": "até",
             "lbNotifications": "Notificações"
         },
@@ -317,6 +317,20 @@ export default {
             "btnFeature": "Por localização",
             "btnBox": "Por região",
             "btnClean": "Limpar"
+        },
+        "viewDownloadMap": {
+            "title": "Baixar mapa",
+            "btnFeature": "Visualização atual",
+            "btnBox": "Mapa de fundo",
+            "modalText": `Devido a alta resolução do mapa, não é possível realizar o download, porém é possível visulizá-lo utilizando o OpenLayers. 
+                            Será aberto uma nova aba, deseja continuar?`,
+            "modalTitle": "Baixar mapa",
+            "modalBtnConfirm": "Sim",
+            "modalBtnCancel": "Voltar",
+            "msg": {
+                "errTitle": "Nenhuma camada de mapa selecionada",
+                "errMsg": "Selecione uma camada de mapa antes de tentar o download"
+            }
         },
         "betaVersionModal": {
             "welcome": "Bem-vindo a plataforma `Pauliceia 2.0`",

--- a/src/views/pages/explore.vue
+++ b/src/views/pages/explore.vue
@@ -10,6 +10,7 @@
       <p-boxinfolayer></p-boxinfolayer>
       <p-boxinfovector></p-boxinfovector>
       <p-boxnotifications></p-boxnotifications>
+      <p-boxdownloadmap></p-boxdownloadmap>
       <p-subtitle :subShow="true"></p-subtitle>
       <p-alert></p-alert>
     </ol-map>
@@ -26,6 +27,7 @@
   import BoxInfoLayer from '@/views/components/map/BoxInfoLayer'
   import BoxInfoVector from '@/views/components/map/BoxInfoVector'
   import BoxInfoNotifications from '@/views/components/map/BoxNotifications'
+  import BoxDownloadMap from '@/views/components/map/BoxDownloadMap'
   import SubtitleMap from '@/views/components/map/SubtitleMap'
   import MapAlert from '@/views/components/map/mapAlert'
 
@@ -49,6 +51,7 @@
       'p-boxinfolayer': BoxInfoLayer,
       'p-boxinfovector': BoxInfoVector,
       'p-boxnotifications': BoxInfoNotifications,
+      'p-boxdownloadmap': BoxDownloadMap,
       "p-subtitle": SubtitleMap,
       "p-alert": MapAlert
     },


### PR DESCRIPTION
Implemented a new popup option that allow users to download their actual map view (with layers added) or to view the background map in a new tab using OpenLayers.

Download actual view:
Added a new option in the UI allowing users to download the current view of the map.
It is a purely client-side implementation, which I had to add a `crossOrigin: "Anonymous"` in the map canvas to allow the download. Not sure about the security impact of this change.

Open background map with OpenLayers:
I wanted to enable users to download high-resolution background maps, but server processing is too heavy, causing timeout in retrieving the images. Therefore, I added an option to open the selected map in a new tab.
