### PR TITLE
Not found addresses log

### DIFF
--- a/src/tests/addresses.csv
+++ b/src/tests/addresses.csv
@@ -1,0 +1,4 @@
+nome da rua,numero,ano
+rua adolpho gordo,41,1909
+rua affonso arinos,2,1909
+rua alagoas,2,1927

--- a/src/tests/features/bdd/download_not_found_addresses_log.feature
+++ b/src/tests/features/bdd/download_not_found_addresses_log.feature
@@ -1,0 +1,10 @@
+# language: pt
+
+Funcionalidade: Baixar arquivo de log dos endereços não enontrados
+
+Cenário: Ao importar os endereços, um ou mais não foram encontrados
+Dado que eu tenha importado um arquivo de endereços
+Quando eu clicar em "Visualizar"
+Então deve abrir uma tela de confirmação
+Quando eu clicar em "Sim"
+Então deve ser baixado um arquivo formato "csv"

--- a/src/tests/features/step_definitions/download_not_found_addresses_log_steps.rb
+++ b/src/tests/features/step_definitions/download_not_found_addresses_log_steps.rb
@@ -1,0 +1,29 @@
+Dado("que eu tenha importado um arquivo de endereços") do
+    visit("http://localhost:8080/portal/explore")
+    
+    find("#close-alert").click
+    find("i", :text => "settings").click
+    find('label.file-select input[type="file"]', visible: false).attach_file(SUPPORT_TESTING[:pathFileCSV], make_visible: true)
+    
+    find('.inputs .el-select:nth-child(1) .el-input__inner').click
+    find('.el-select-dropdown__item', text: 'nome da rua').click
+    find('.inputs .el-select:nth-child(2) .el-input__inner').click
+    find('.el-select-dropdown__item', text: 'numero').click
+    find('.inputs .el-select:nth-child(3) .el-input__inner').click
+    find('.el-select-dropdown__item', text: 'ano').click
+
+    find('.btn-download', visible: :visible).click(wait: 10)
+    sleep 5
+end
+
+Quando("eu clicar em {string}") do |buttonText|
+    find('button', :text => buttonText)
+end
+
+Então("deve abrir uma tela de confirmação") do
+    find('.popup-modal')
+end
+
+Então("deve ser baixado um arquivo formato {string}") do |fileFormat|
+
+end

--- a/src/tests/features/step_definitions/open_download_options_steps.rb
+++ b/src/tests/features/step_definitions/open_download_options_steps.rb
@@ -11,15 +11,3 @@ Então('deve aparecer uma tela com os botões {string} e {string}') do |button1,
     find("button", :text => button1)
     find("button", :text => button2)
 end
-# E('clico em "Mapa de fundo"') do
-#     find('#download-background-map').click
-# end
-
-# E('clico em "Sim"') do
-#     find("#ok-button").click
-# end
-
-# Então("deve abrir uma nova aba com o mapa selecionado") do
-#     page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
-# end
-  

--- a/src/tests/features/support/credential.rb
+++ b/src/tests/features/support/credential.rb
@@ -7,3 +7,7 @@ CREDENCIAL = {
   username: 'pauliceiateste',
   refABNT: 'Autor: Sobrenome, Iniciais do(s) Nome(s). Título do Livro. Edição (se não for a primeira). Local de publicação: Editora, Ano de publicação. Número total de páginas (se aplicável).'
 }
+
+SUPPORT_TESTING = {
+  pathFileCSV: 'addresses.csv',
+}

--- a/src/views/assets/js/map/multiplegeocode.js
+++ b/src/views/assets/js/map/multiplegeocode.js
@@ -39,8 +39,20 @@ function CSVToArray(strData, strDelimiter) {
       return (arrData);
 } 
 
+function jsonToCSV(json) {
+    const replacer = (key, value) => value === null ? '' : value
+    const header = Object.keys(json[0])
+    const csv = [
+    header.join(','),
+    ...json.map(row => header.map(fieldName => JSON.stringify(row[fieldName], replacer)).join(','))
+    ].join('\r\n')
+
+    return csv;
+}
+
 export {
     CSV2JSON,
     CSVToArray,
+    jsonToCSV,
     getUrl
 }

--- a/src/views/components/PopupModal.vue
+++ b/src/views/components/PopupModal.vue
@@ -48,7 +48,7 @@ export default {
     padding: 0.5rem;
     display: flex;
     align-items: center;
-    z-index: 1;
+    z-index: 999999;
 }
 
 .window {

--- a/src/views/components/map/mapAlert.vue
+++ b/src/views/components/map/mapAlert.vue
@@ -2,7 +2,7 @@
   <section class="boxS" v-show="boxAlert">
     <header class="header">
       <img src="@/views/assets/images/logo.png" class="img">
-      <button class="btn" @click="closeBox()">
+      <button class="btn" id="close-alert" @click="closeBox()">
         <md-icon>close</md-icon>
       </button>
       <br>

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -258,6 +258,12 @@ export default {
                 "found": "Found",
                 "geocoded": "Geocoded",
                 "extrapolated": "Extrapolated"
+            },
+            "downloadCSVModal": {
+                "modalText": `One or more addresses weren't found. Do you want to download the logs file?`,
+                "modalTitle": "Not found",
+                "modalBtnConfirm": "Yes",
+                "modalBtnCancel": "No",
             }
         },
         "sidebarLayer": {

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -259,6 +259,12 @@ export default {
                 "found": "Encontrado",
                 "geocoded": "Geocodificado",
                 "extrapolated": "Extrapolado"
+            },
+            "downloadCSVModal": {
+                "modalText": `Um ou mais endereços não foram encontrados. Deseja fazer o download dos logs?`,
+                "modalTitle": "Não encontrado",
+                "modalBtnConfirm": "Sim",
+                "modalBtnCancel": "Não",
             }
         },
         "sidebarLayer": {


### PR DESCRIPTION
I implemented an option to download a CSV file containing all addresses not found during the upload of the addresses file. 

After the upload, the geocoding process attempts to find the addresses; if any are not found, a message appears, offering the user the option to download a log file. 

This change has a minor impact on the project.