### PR TITLE
Add new slider single year selection

### DIFF
--- a/src/tests/features/bdd/filter_single_year.feature
+++ b/src/tests/features/bdd/filter_single_year.feature
@@ -1,0 +1,12 @@
+# language: pt
+
+Funcionalidade: Filtrar apenas um ano
+    Cenário: Filtrar apenas um ano
+        Dado a pagina incial
+        Quando eu abro o menu de adicionar camadas
+        E adiciono a camada de "Cinemas between 1900 to 1950"
+        E no slider "Seleção de um espaço de tempo" seleciono "1895" como maximo do periodo
+        Então nao devo ver mais a camada que apresenta dados de 1900 ate 1950
+
+        E no slider "Seleção de um único ano" seleciono "1905"
+        Então devo voltar a ver a camada de 1900 ate 1950

--- a/src/tests/features/step_definitions/filter_single_year.rb
+++ b/src/tests/features/step_definitions/filter_single_year.rb
@@ -1,0 +1,41 @@
+include Capybara::DSL
+
+Dado('a pagina incial') do
+  visit('http://localhost:8080/portal/explore')
+end
+
+#armazena o estilo inicial da pagina para comparar com o novo mapa
+@page_initial = page.evaluate_script('getComputedStyle(document.body).backgroundColor')
+
+Quando('eu abro o menu de adicionar camadas') do
+  #find('section.boxS button.btn i.md-icon-font', text: 'close').click
+  find('p.btn_sidebar').click
+  find('div.md-button-content img[src="/portal/static/img/add-layer.5bcee7e.png"]').find(:xpath, '..').click
+end
+
+E('adiciono a camada de {string}') do |camada|
+  element = find('div.box-layer-info p', text: "TÍTULO: #{camada}").ancestor('.box-layer-info')
+  element.find('button', text: "Ativar").click
+  find('button[data-dismiss="modal"][aria-label="Close"]').click
+end
+
+#armazena o estilo com camada da pagina para comparar com o novo mapa
+@page_with_layer = page.evaluate_script('getComputedStyle(document.body).backgroundColor')
+
+E('no slider "Seleção de um espaço de tempo" seleciono {string} como maximo do periodo') do |ano|
+  find('#slider').set("#{ano}")
+end
+
+Então('nao devo ver mais a camada que apresenta dados de 1900 ate 1950') do 
+  new_background_color = page.evaluate_script('getComputedStyle(document.body).backgroundColor')
+  expect(new_background_color).not_to eq(@page_with_layer)
+end
+
+E('no slider "Seleção de um único ano" seleciono {string}') do |ano|
+  find('#slider1year').set("#{ano}")
+end
+
+Então('devo voltar a ver a camada de 1900 ate 1950') do 
+  new_background_color = page.evaluate_script('getComputedStyle(document.body).backgroundColor')
+  expect(new_background_color).not_to eq(@page_initial)
+end

--- a/src/views/components/map/Timeline.vue
+++ b/src/views/components/map/Timeline.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="contentSlider">
     <div class="sliders" id="slider"></div>
+    <div class="slider1year" id="slider1year"></div>
   </div>
 </template>
 
@@ -95,6 +96,44 @@
         this.$store.dispatch('map/setYears', {
           first: values[0],
           last: values[1]
+        })
+
+        this.filterUpdate()
+      })
+
+      // Second slider
+      let slider1year = document.getElementById('slider1year')
+
+      noUiSlider.create(slider1year, {
+        start: [this.sliderStartYear],
+        connect: 'lower',
+        orientation: 'horizontal',
+        step: 1,
+        tooltips: true,
+        direction: 'ltr',
+        range: {
+          'min': this.sliderStartYear,
+          'max': this.sliderEndYear
+        },
+        pips: {
+          mode: 'count',
+          values: 5,
+          density: 4
+        },
+        format: {
+          to: value => {
+            return value + ''
+          },
+          from: value => {
+            return value.replace(',-', '')
+          }
+        }
+      })
+
+      slider1year.noUiSlider.on('update', (values, handle) => {
+        this.$store.dispatch('map/setYears', {
+          first: values[0],
+          last: values[0]
         })
 
         this.filterUpdate()
@@ -200,5 +239,18 @@
 
   #contentSlider .sliders .noUi-connect{
     background: #58595b !important;
+  }
+
+  #contentSlider .slider1year{
+    position: relative;
+    width: 84%;
+    height: 10px;
+    margin-left: 8%;
+    margin-right: 5%;
+    bottom: -10px;
+  }
+
+  #contentSlider .slider1year .noUi-connect{
+    background: #79ca4a !important;
   }
 </style>

--- a/src/views/components/map/Timeline.vue
+++ b/src/views/components/map/Timeline.vue
@@ -1,7 +1,15 @@
 <template>
   <div id="contentSlider">
-    <div class="sliders" id="slider"></div>
-    <div class="slider1year" id="slider1year"></div>
+    <div class="slider-container">
+      <div class="slider-title">Seleção de um espaço de tempo</div>
+      <div class="sliders" id="slider"></div>
+    </div>
+
+    <div class="slider-container">
+      <div class="slider-title">Seleção de um único ano</div>
+      <div class="slider1year" id="slider1year"></div>
+    </div>
+    
   </div>
 </template>
 
@@ -222,11 +230,28 @@
     display: flex;
     z-index: 2;
     bottom: 35px;
-    height: 65px;
+    height: 120px;
     width: 40%;
     background-color: rgba(255, 255, 255, 0.7);
     right: 30%;
     border-radius: 10px;
+  }
+
+  .slider-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .slider-title {
+    font-size: 12px;
+    color: #0c0c0c;
+    height: 10px;
+    margin-left: 8%;
+    bottom: -10px;
+  
   }
 
   #contentSlider .sliders{
@@ -251,6 +276,11 @@
   }
 
   #contentSlider .slider1year .noUi-connect{
-    background: #79ca4a !important;
+    background: #ffffff !important;
   }
+
+
+
+
+  
 </style>


### PR DESCRIPTION
The PR is regarding a new slider for single year selection. As said by the owners of the project, selecting a range of time is useful but they needed a single year selector.
The new slider follows the same design of the first one, it was included side-by-side and a title was added to identify the usability. 

We performed tests to check if the new slider was working and to check that when one of slider is select the other stop working avoiding double time ranges.  Using cucumber and capybara.