### PR TITLE
Add random color in geometry styles

### DIFF
--- a/src/tests/features/bdd/verificar_se_cor_camada_diferente_de_vermelho.feature
+++ b/src/tests/features/bdd/verificar_se_cor_camada_diferente_de_vermelho.feature
@@ -6,7 +6,7 @@ Para que eu possa visualizar melhor as layers que estão no mapa
 Eu quero ter cores diferentes entre as point layers 
 
 Cenário: Abrir as informações da camada
-  Dado que estou na página de mapa, abri o seletor de camadas e ativei as camadas "Edificios construidos na Avenida Sao Joao entre 1913 e 1936" e "Farmacias do ano de 1920 em Sao Paulo"
+  Dado que estou na página de mapa, abri o seletor de camadas e ativei as camadas "Addresses in 1869" e "Robberies between 1880 to 1900"
   Quando eu clico no botão de configurações da camada posicionada na posicao 1
   E eu clico no botão de configurações da camada posicionada na posicao 2
   Então vejo que as cores são diferentes

--- a/src/tests/features/bdd/verificar_se_cor_camada_diferente_de_vermelho.feature
+++ b/src/tests/features/bdd/verificar_se_cor_camada_diferente_de_vermelho.feature
@@ -1,0 +1,12 @@
+# language: pt
+
+Funcionalidade: Ter cores diferentes entre point layers
+Como um usuário do Pauliceia 2.0
+Para que eu possa visualizar melhor as layers que estão no mapa
+Eu quero ter cores diferentes entre as point layers 
+
+Cenário: Abrir as informações da camada
+  Dado que estou na página de mapa, abri o seletor de camadas e ativei as camadas "Edificios construidos na Avenida Sao Joao entre 1913 e 1936" e "Farmacias do ano de 1920 em Sao Paulo"
+  Quando eu clico no botão de configurações da camada posicionada na posicao 1
+  E eu clico no botão de configurações da camada posicionada na posicao 2
+  Então vejo que as cores são diferentes

--- a/src/tests/features/step_definitions/filter_by_author_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/filter_by_author_add_layer_steps.rb
@@ -9,7 +9,7 @@ Quando('eu filtro pelo autor {string}') do |author|
 end
 
 Então('todos os resultados visiveis devem conter {string} ou {string}') do |termo_pesquisa1, termo_pesquisa2|
-  elements = all('.box-layer-info')
+  elements = page.all('.box-layer-info')
 
   all_elements_contain_search = elements.all? do |element|
     element.text.include?(termo_pesquisa1) || element.text.include?(termo_pesquisa2)

--- a/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
@@ -3,7 +3,7 @@ Dado('eu pesquiso por {string}') do |termo_pesquisa|
 end
 
 Então('todos os resultados visiveis devem conter {string}') do |termo_pesquisa|
-  elements = all('.box-layer-info')
+  elements = page.all('.box-layer-info')
   all_elements_contain_search = elements.all? { |element| element.text.include?(termo_pesquisa) }
   expect(all_elements_contain_search).to be true
 end

--- a/src/tests/features/step_definitions/verificar_se_cor_camada_diferente_de_vermelho_steps.rb
+++ b/src/tests/features/step_definitions/verificar_se_cor_camada_diferente_de_vermelho_steps.rb
@@ -1,0 +1,51 @@
+def clicar_acao_camada(acao, camada)
+  element = find('div.box-layer-info p', text: "TÍTULO: #{camada}").ancestor('.box-layer-info')
+  element.find('button', text: "#{acao}").click
+end
+
+Dado("que estou na página de mapa, abri o seletor de camadas e ativei as camadas {string} e {string}") do |camada, camada2|
+  puts "Camada 1: #{camada}"
+  puts "Camada 2: #{camada2}"
+ 
+  steps %Q{
+    Dado que estou na página de mapa com o popup de bem-vindo fechado
+    Quando abro o seletor de camadas
+    E eu clico no botão "Ativar" da camada "#{camada2}"
+    E eu clico no botão "Ativar" da camada "#{camada}"
+    E eu clico no icone de fechar
+    Então eu devo ver 2 elementos com a classe 'move-icon' na página 
+  }
+end
+
+Quando('eu clico no botão de configurações da camada posicionada na posicao {int}') do |posicao|
+  xpath_expression = "(//button[@class='btn-view']/i[@class='md-icon md-icon-font md-theme-default'])[#{posicao}]"
+  btn = find(:xpath,xpath_expression)
+  btn.click
+end
+
+Então("vejo que as cores são diferentes") do
+  # Encontra os dois elementos com a classe el-color-picker__color-inner
+  elementos = all('.el-color-picker__color-inner')
+
+  elemento1 = find(:xpath,"(//span[@class='el-color-picker__color-inner'])[1]")
+  elemento2 = find(:xpath,"(//span[@class='el-color-picker__color-inner'])[2]")
+
+  background1 = elemento1.style('background-color')
+  background2 = elemento2.style('background-color')
+
+  expect(background1).not_to eq(background2)
+end
+
+
+Então("eu devo ver {int} elementos com a classe {string} na página") do |quantidade, classe|
+  elementos = page.all(".#{classe}")
+  expect(elementos.count).to eq(quantidade)
+end
+
+Quando('eu clico no botão {string} da camada {string}') do |acao, camada|
+  clicar_acao_camada(acao, camada)
+end
+
+Quando('eu clico no icone de fechar') do
+  find('button[data-dismiss="modal"][aria-label="Close"]').click
+end

--- a/src/tests/features/step_definitions/verificar_se_cor_camada_diferente_de_vermelho_steps.rb
+++ b/src/tests/features/step_definitions/verificar_se_cor_camada_diferente_de_vermelho_steps.rb
@@ -3,6 +3,20 @@ def clicar_acao_camada(acao, camada)
   element.find('button', text: "#{acao}").click
 end
 
+
+#temp
+Dado('que estou na página de mapa com o popup de bem-vindo fechado') do
+  # local: http://0.0.0.0:8080/portal/explore
+  # https://pauliceia.unifesp.br/portal/explore
+  visit('http://localhost:8080/portal/explore')
+  find('section.boxS button.btn i.md-icon-font', text: 'close').click
+end
+Quando('abro o seletor de camadas') do
+  find('p.btn_sidebar').click
+  find('div.md-button-content img[src="/portal/static/img/add-layer.5bcee7e.png"]').find(:xpath, '..').click
+end
+# temp
+
 Dado("que estou na página de mapa, abri o seletor de camadas e ativei as camadas {string} e {string}") do |camada, camada2|
   puts "Camada 1: #{camada}"
   puts "Camada 2: #{camada2}"
@@ -25,7 +39,7 @@ end
 
 Então("vejo que as cores são diferentes") do
   # Encontra os dois elementos com a classe el-color-picker__color-inner
-  elementos = all('.el-color-picker__color-inner')
+  elementos = page.all('.el-color-picker__color-inner')
 
   elemento1 = find(:xpath,"(//span[@class='el-color-picker__color-inner'])[1]")
   elemento2 = find(:xpath,"(//span[@class='el-color-picker__color-inner'])[2]")

--- a/src/views/assets/js/map/Styles.js
+++ b/src/views/assets/js/map/Styles.js
@@ -2,47 +2,6 @@ import icon_ext from './../../images/iconExtrapolate.png'
 import icon_geo from './../../images/iconGeocoding.png'
 import icon_loc from './../../images/iconGeolocation.png'
 
-/*
-  WARNING:
-
-  Do NOT use a `string color` (i.e. blue, black, etc.) as a fill color, use an `hexadecimal` or `RGBA` color instead,
-  because if you use a `string color`, this color will not be recognized by the color picker on the map as default color.
-*/
-
-const pointStyle = new ol.style.Style({
-  image: new ol.style.Circle({
-    radius: 8,
-    stroke: new ol.style.Stroke({
-      // white
-      color: 'rgba(255, 255, 255, 1)',
-      width: 2
-    }),
-    fill: new ol.style.Fill({
-      // red
-      color: 'rgba(255, 0, 0, 1)'
-    })
-  })
-});
-
-const lineStyle = new ol.style.Style({
-  stroke: new ol.style.Stroke({
-    // blue
-    color: 'rgba(0, 0, 255, 1)',
-    width: 3
-  })
-})
-
-const polygonStyle = new ol.style.Style({
-  stroke: new ol.style.Stroke({
-    // black
-    color: 'rgba(0, 0, 0, 1)',
-    width: 3
-  }),
-  fill: new ol.style.Fill({
-    // transparent white
-    color: 'rgba(255, 255, 255, 0.5)'
-  })
-});
 
 const placeStyleSearch1 = new ol.style.Style({
   image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
@@ -79,9 +38,6 @@ const emptyStyle = new ol.style.Style({
 })
 
 export {
-  pointStyle,
-  polygonStyle,
-  lineStyle,
   placeStyleSearch1,
   placeStyleSearch3,
   placeStyleSearch0,

--- a/src/views/assets/js/map/geometricStyle.js
+++ b/src/views/assets/js/map/geometricStyle.js
@@ -1,0 +1,46 @@
+/*
+  WARNING:
+
+  Do NOT use a `string color` (i.e. blue, black, etc.) as a fill color, use an `hexadecimal` or `RGBA` color instead,
+  because if you use a `string color`, this color will not be recognized by the color picker on the map as default color.
+*/
+
+const DEFAULT_STROKE_COLOR = 'rgba(255, 255, 255, 1)';
+const DEFAULT_FILL_COLOR = 'rgba(0, 0, 0, 1)';
+const DEFAULT_FILL_COLOR_TRANSPARENT = 'rgba(255, 255, 255, 0.5)';
+const DEFAULT_STROKE_WIDTH = 3;
+const DEFAULT_RADIUS = 8;
+
+const getRandomColor = (alpha = 1) => `rgba(${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${Math.floor(Math.random() * 256)}, ${alpha})`;
+
+const getStroke = (color = DEFAULT_STROKE_COLOR) => new ol.style.Stroke({
+    color,
+    width: DEFAULT_STROKE_WIDTH
+});
+
+const getPointStyle = (random = false) => new ol.style.Style({
+    image: new ol.style.Circle({
+        radius: DEFAULT_RADIUS,
+        stroke: getStroke(),
+        fill: new ol.style.Fill({
+            color: random ? getRandomColor(1) : DEFAULT_FILL_COLOR
+        })
+    })
+});
+
+const getLineStyle = (random = false) => new ol.style.Style({
+    stroke: getStroke(random ? getRandomColor(1) : 'rgba(0, 0, 255, 1)')
+});
+
+const getPolygonStyle = (random = false) => new ol.style.Style({
+    stroke: getStroke(),
+    fill: new ol.style.Fill({
+        color: random ? getRandomColor(0.5) : DEFAULT_FILL_COLOR_TRANSPARENT
+    })
+});
+
+export {
+    getPointStyle,
+    getLineStyle,
+    getPolygonStyle
+};

--- a/src/views/components/map/sidebar-layer/LayersItem.vue
+++ b/src/views/components/map/sidebar-layer/LayersItem.vue
@@ -51,11 +51,10 @@
 <script>
 import { mapState } from 'vuex'
 import {
-    emptyStyle,
-    lineStyle,
-    polygonStyle,
-    pointStyle
-} from '@/views/assets/js/map/Styles'
+    getPointStyle,
+    getLineStyle,
+    getPolygonStyle
+} from '@/views/assets/js/map/geometricStyle'
 import Map from '@/middleware/Map'
 import Dashboard from '@/middleware/Dashboard'
 
@@ -177,18 +176,27 @@ export default {
               let styleType = typeof(layer.getStyle())
 
               if (this.type === 'multilinestring' || this.type === 'linestring') {
+
+                const lineStyle = getLineStyle();
+
                 if (styleType === 'function')
                   layer.setStyle(lineStyle)
 
                 this.colorVector = lineStyle.getStroke().getColor()
 
               } else if (this.type === 'multipoint' || this.type === 'point') {
+
+                const pointStyle = getPointStyle(true);
+
                 if (styleType === 'function')
                   layer.setStyle(pointStyle)
 
                 this.colorVector = pointStyle.getImage().getFill().getColor()
 
               } else if (this.type === 'multipolygon' || this.type === 'polygon') {
+
+                const polygonStyle = getPolygonStyle();
+
                 if (styleType === 'function')
                   layer.setStyle(polygonStyle)
 


### PR DESCRIPTION
The changes in this pr mean that, when layers with point style are added, these points initialize with random colors. Additionally, the way in which the styles of each layer type (line, polygonal, point) have been reworked allowing them to be easily changed to generate random colors or the previously implemented default colors.

The change was carried out using TDD. The test for this PR are inside features and steps folders with the name verificar_se_cor_camada_diferente_de_vermelho. Earlier made acceptance tests were executed to make sure that no other part of the application was damaged by the additions of this PR. 

No big structural changes were made. When adding this contribution to the code, the old way to create layer styles will be deleted from Styles.js and another file, geometricStyles.js, will contain the new way to create these styles. Addicionaly, the component LayerItem will incorporate this functions to generate random colors to the pointStyle. If the team finds it necessary for all styles to have random colors, simply add the true argument to the part where the styles are created. For example, if you want polygonal styles to also have randomness in their colors, change:

const polygonStyle = getPolygonStyle();

to:

const polygonStyle = getPolygonStyle(true);

This code has been refined to eliminate redundancies and enhance clarity, resulting in a more robust foundation. The use of specialized functions, such as getStroke and getRandomColor, promotes code reuse, reducing duplication. The introduction of constants for colors and default values contributes to readability and maintainability, facilitating future modifications. Furthermore, the consistent structure and adherence to best practices make the code more cohesive, avoiding undesirable qualities like redundancy and unnecessary complexity. These improvements contribute to cleaner, more comprehensible code.