### PR TITLE
Add description in add layer

### DIFF
--- a/src/tests/features/bdd/verificar_pop_up_descricao.feature
+++ b/src/tests/features/bdd/verificar_pop_up_descricao.feature
@@ -1,0 +1,12 @@
+# language: pt
+
+Funcionalidade: Ver descrição da camada antes de adicioná-la ao mapa
+Como um usuário do Pauliceia 2.0
+Para que eu possa saber do que se trata a camada antes de adicioná-la ao mapa 
+Eu quero ver a descrição da camada antes de adicioná-la ao mapa
+
+Cenário: Abrir as informações da camada
+  Dado que estou na página de mapa com o popup de bem-vindo fechado
+  Quando abro o seletor de camadas 
+  E clico no botão "DESCRIÇÃO"
+  Então eu vejo o popup da descrição

--- a/src/tests/features/step_definitions/filter_by_author_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/filter_by_author_add_layer_steps.rb
@@ -9,7 +9,7 @@ Quando('eu filtro pelo autor {string}') do |author|
 end
 
 Então('todos os resultados visiveis devem conter {string} ou {string}') do |termo_pesquisa1, termo_pesquisa2|
-  elements = all('.box-layer-info')
+  elements = page.all('.box-layer-info')
 
   all_elements_contain_search = elements.all? do |element|
     element.text.include?(termo_pesquisa1) || element.text.include?(termo_pesquisa2)

--- a/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
+++ b/src/tests/features/step_definitions/search_temporal_data_add_layer_steps.rb
@@ -3,7 +3,7 @@ Dado('eu pesquiso por {string}') do |termo_pesquisa|
 end
 
 Então('todos os resultados visiveis devem conter {string}') do |termo_pesquisa|
-  elements = all('.box-layer-info')
+  elements = page.all('.box-layer-info')
   all_elements_contain_search = elements.all? { |element| element.text.include?(termo_pesquisa) }
   expect(all_elements_contain_search).to be true
 end

--- a/src/tests/features/step_definitions/verificar_pop_up_descricao_steps.rb
+++ b/src/tests/features/step_definitions/verificar_pop_up_descricao_steps.rb
@@ -11,7 +11,7 @@ Quando('abro o seletor de camadas') do
 end
 
 E("clico no botão {string}") do | buttonText | 
-  find_all("span", :text => buttonText)[0].click
+  page.find_all("span", :text => buttonText)[0].click
 end
 
 Então ('eu vejo o popup da descrição') do 

--- a/src/tests/features/step_definitions/verificar_pop_up_descricao_steps.rb
+++ b/src/tests/features/step_definitions/verificar_pop_up_descricao_steps.rb
@@ -1,0 +1,19 @@
+Dado('que estou na página de mapa com o popup de bem-vindo fechado') do
+  # local: http://0.0.0.0:8080/portal/explore
+  # https://pauliceia.unifesp.br/portal/explore
+  visit('http://localhost:8080/portal/explore')
+  find('section.boxS button.btn i.md-icon-font', text: 'close').click
+end
+
+Quando('abro o seletor de camadas') do
+  find('p.btn_sidebar').click
+  find('div.md-button-content img[src="/portal/static/img/add-layer.5bcee7e.png"]').find(:xpath, '..').click
+end
+
+E("clico no botão {string}") do | buttonText | 
+  find_all("span", :text => buttonText)[0].click
+end
+
+Então ('eu vejo o popup da descrição') do 
+  find(".v-modal")
+end

--- a/src/views/components/map/sidebar-layer/AddLayers.vue
+++ b/src/views/components/map/sidebar-layer/AddLayers.vue
@@ -70,6 +70,19 @@
                     {{ name }}
                   </el-tag>
                 </p>
+                <div class="btns">
+                  <el-button @click="showDescription(layer.properties.description)" size="small" type="info" round>{{
+                    $t('map.addLayer.box.lbDescription') }}</el-button> 
+                  <el-dialog :title="$t('map.addLayer.box.lbDescription')" :visible.sync="showDescriptionDialog"
+                    width="30%" center append-to-body>
+                    <p>{{ selectedLayerDescription }}</p>
+                    <span class="dialog-footer">
+                      <el-button @click="closeDescriptionDialog">{{ $t('map.addLayer.close') }}</el-button>
+                    </span>
+                  </el-dialog>
+                </div>
+
+
               </div>
 
               <div class="btns">
@@ -140,6 +153,8 @@ export default {
         allTemporalData: [],
         allAuthors: [],
         showFilters: false,
+        showDescriptionDialog: false,
+        selectedLayerDescription: '',
       }
     },
     async mounted() {
@@ -196,6 +211,17 @@ export default {
       }
     },
     methods: {
+      // method to show description in a dialog
+      showDescription(description) {
+        this.selectedLayerDescription = description;
+        this.showDescriptionDialog = true;
+      },
+
+      // method to close the description dialog
+      closeDescriptionDialog() {
+        this.showDescriptionDialog = false;
+        this.selectedLayerDescription = '';
+      },
       getKeywordById(id){
         return this.allKeywords.filter(key => key.properties.keyword_id === id)
       },

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -293,6 +293,7 @@ export default {
                 "lbTitle": "TÍTULO",
                 "lbAuthors": "AUTORES",
                 "lbKeywods": "PALAVRAS-CHAVE",
+                "lbDescription": "DESCRIÇÃO",
                 "lbTemporalData": "DADOS TEMPORAIS",
                 "lbUntil": "até",
             },


### PR DESCRIPTION
I implemented a button in the add Layer tab that opens a popup with the layer description.

The change was carried out using TDD. The test for this PR are inside features and steps folders with the name verificar_pop_up_descricao_steps. Earlier made acceptance tests were executed to make sure that no other part of the application was damaged by the additions of this PR. 

The code exhibits good development practices with its organized and readable structure, efficient use of the Vue.js state management system, and clear event logic. The reuse of Element UI components contributes to a robust and easily maintainable structure.

No big structural changes were made. When adding this contribution to the code, only the translation to description and the addLayer will be changed with the inclusion of this changes.