### PR TITLE
Add layer delete confirmation

### DIFF
--- a/src/tests/features/bdd/delete_layer.feature
+++ b/src/tests/features/bdd/delete_layer.feature
@@ -1,0 +1,27 @@
+#language: pt
+
+Funcionalidade: Adição de nova camada pelo usuário logado
+
+    Contexto: Dado que estou na página do painel
+
+    Cenario: Remoção de camada determinada
+    Como o usuário da plataforma
+    Eu quero remover de uma camada que criei
+    Para que outras pessoas não a utilizem
+
+        Dado que estou na página do painel
+        Quando eu seleciono o botão de remoção da camada que quero excluir
+        Então eu devo ver um pop-up pedindo a confirmação de remoção
+        Quando eu clico no botão de confirmação
+        Então a camada é excluída
+
+    Cenario: Remoção de camada desistente
+    Como o usuário da plataforma
+    Eu quero remover de uma camada que criei
+    Para que outras pessoas não a utilizem
+
+        Dado que estou na página do painel
+        Quando eu seleciono o botão de remoção da camada que quero excluir
+        Então eu devo ver um pop-up pedindo a confirmação de remoção
+        Quando eu clico no botão de cancelamento da remoção
+        Então a camada não é excluída

--- a/src/tests/features/step_definitions/delete_layer_steps.rb
+++ b/src/tests/features/step_definitions/delete_layer_steps.rb
@@ -1,0 +1,45 @@
+Dado('que estou na página do painel') do
+  
+  visit('http://localhost:8080/portal/explore')
+
+  #login
+  find('a[href="/portal/login"]').click
+  page.fill_in('E-mail', with: 'admin@admin.com')
+  page.fill_in('Senha', with: 'admin')
+  find('button[type="submit"]', text: 'Entrar').click
+
+  find(".md-avatar").click
+
+  find(:xpath, "//a[@href='/portal/dashboard']").click
+end
+  
+Quando('eu seleciono o botão de remoção da camada que quero excluir') do
+  sleep(1)
+  elements = find_all(".add2")
+  @countEls = elements.length
+  elements[0].click
+end
+
+Então('eu devo ver um pop-up pedindo a confirmação de remoção') do
+  expect(page).to have_css('.el-message-box__header', visible: true)
+end
+
+Quando('eu clico no botão de confirmação') do
+  find('.el-button--primary').click
+end
+
+Então('a camada é excluída') do
+  sleep(1)
+  elements = find_all(".add2")
+  expect(elements.length == @countEls).to be false
+end
+
+Quando('eu clico no botão de cancelamento da remoção') do
+  find('span', :text => 'Cancelar')
+end
+
+Então('a camada não é excluída') do
+  sleep(1)
+  elements = find_all(".add2")
+  expect(elements.length == @countEls).to be true
+end

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -30,6 +30,12 @@ export default {
             "myLayers": "My Layers",
             "sharedLayers": "Shared Layers"
         },
+        "deleteLayer": {
+            "confirmMessage": "Are you sure you want to delete the layer?",
+            "Confirmation": "Confirmation",
+            "confirmButtonText": "Confirm",
+            "cancelButtonText": "Cancel",
+        },
         "newLayer": {
             "name": "Name",
             "keywords": "Keywords",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -30,6 +30,12 @@ export default {
             "myLayers": "Minhas Camadas",
             "sharedLayers": "Camadas Compartilhadas"
         },
+        "deleteLayer": {
+            "confirmMessage": "Você tem certeza de que deseja excluir a camada?",
+            "Confirmation": "Confirmação",
+            "confirmButtonText": "Confirmar",
+            "cancelButtonText": "Cancelar",
+        },
         "newLayer": {
             "name": "Nome",
             "keywords": "Palavras-chave",

--- a/src/views/pages/dashboard/home.vue
+++ b/src/views/pages/dashboard/home.vue
@@ -24,8 +24,9 @@
             <div class="card-text">
               <div class="row" v-for="layer in myLayers" v-bind:key="layer.layer_id">
                 <div class="col-sm-7">{{ layer.name }}</div>
+                <!-- div com o botao de confirmacao de deletar camada -->
                 <div class="col-sm-5">
-                  <button type="button" class="btn btn-outline-danger btn-sm add2" @click="deleteLayer(layer.layer_id)"><md-icon>clear</md-icon></button>
+                  <button type="button" class="btn btn-outline-danger btn-sm add2" @click="showDeleteConfirmation(layer.layer_id)"><md-icon>clear</md-icon></button>
                   <button type="button" class="btn btn-outline-dark btn-sm add" @click="editLayer(layer.layer_id)"><md-icon>create</md-icon></button>
                 </div>
                 <hr>
@@ -65,6 +66,7 @@
   import Api from '@/middleware/ApiVGI'
   import { mapState } from 'vuex'
   import Notifications from '@/views/components/dashboard/Notifications'
+  import { MessageBox } from 'element-ui';
 
   export default {
     data () {
@@ -87,6 +89,23 @@
           this.updateLayers()
         })
       },
+      // método para confirmar se o uusuario deseja excluir a camada
+      showDeleteConfirmation(layerId) {
+      const confirmMessage = `Você tem certeza de que deseja excluir a camada?`;
+
+      MessageBox.confirm(confirmMessage, 'Confirmação', {
+        confirmButtonText: 'Confirmar',
+        cancelButtonText: 'Cancelar',
+        type: 'warning'
+      })
+        .then(() => {
+          // Se o usuário confirmar, chame o método de exclusão
+          this.deleteLayer(layerId);
+        })
+        .catch(() => {
+          // Se o usuário cancelar, não faça nada
+        });
+    },
       editLayer(id){
         this.$router.push({name: 'EditLayer', params: {layer_id: id}})
       },

--- a/src/views/pages/dashboard/home.vue
+++ b/src/views/pages/dashboard/home.vue
@@ -91,11 +91,11 @@
       },
       // método para confirmar se o uusuario deseja excluir a camada
       showDeleteConfirmation(layerId) {
-      const confirmMessage = `Você tem certeza de que deseja excluir a camada?`;
+      const confirmMessage = this.$t('dashboard.deleteLayer.confirmMessage');
 
-      MessageBox.confirm(confirmMessage, 'Confirmação', {
-        confirmButtonText: 'Confirmar',
-        cancelButtonText: 'Cancelar',
+      MessageBox.confirm(confirmMessage, this.$t('dashboard.deleteLayer.Confirmation'), {
+        confirmButtonText: this.$t('dashboard.deleteLayer.confirmButtonText'),
+        cancelButtonText: this.$t('dashboard.deleteLayer.cancelButtonText'),
         type: 'warning'
       })
         .then(() => {


### PR DESCRIPTION
I implemented a confirmation pop-up that appears when the user clicks on the layer removal button.

The change was made using Test-Driven Development (TDD). The tests for this PR are located in the "features" and "steps" folders with the name "delete_layer". Acceptance tests were previously executed to ensure that no other part of the application was affected by the addition of this PR.

The code demonstrates good development practices, with an organized and readable structure, efficient use of the Vue.js state management system, and clear event logic. The reuse of Element UI components contributes to a robust and easily maintainable structure.

No major structural changes were made. When adding this contribution to the code, only the translation for the removal confirmation button and the file "src/views/pages/dashboard/home.vue" will be modified with the inclusion of these changes.